### PR TITLE
Bumped Fabric version

### DIFF
--- a/fabric/requirements.txt
+++ b/fabric/requirements.txt
@@ -1,4 +1,4 @@
-Fabric==1.10
+Fabric==1.10.3
 boto==2.34
 shortuuid==0.2
 pexpect==2.4


### PR DESCRIPTION
Need to bump Fabric to 1.10.3.  1.10 now breaks with the following message:

```
Traceback (most recent call last):
  File "/Users/pm5/src/localwiki/vagrant_localwiki/env/bin/fab", line 7, in <module>
    from fabric.main import main
  File "/Users/pm5/src/localwiki/vagrant_localwiki/env/lib/python2.7/site-packages/fabric/main.py", line 19, in <module>
    from fabric import api, state, colors
  File "/Users/pm5/src/localwiki/vagrant_localwiki/env/lib/python2.7/site-packages/fabric/api.py", line 11, in <module>
    from fabric.decorators import (hosts, roles, runs_once, with_settings, task,
  File "/Users/pm5/src/localwiki/vagrant_localwiki/env/lib/python2.7/site-packages/fabric/decorators.py", line 9, in <module>
    from Crypto import Random
ImportError: No module named Crypto
```
